### PR TITLE
class04を追加

### DIFF
--- a/class04/docker-compose.yaml
+++ b/class04/docker-compose.yaml
@@ -1,0 +1,33 @@
+version: '3.8'
+
+services:
+  wordpress:
+    image: wordpress:latest
+    container_name: wordpress
+    ports:
+      - "8000:80"
+    environment:
+      WORDPRESS_DB_HOST: db:3306
+      WORDPRESS_DB_USER: wordpress_user
+      WORDPRESS_DB_PASSWORD: wordpress_pass
+      WORDPRESS_DB_NAME: wordpress_db
+    volumes:
+      - wordpress_data:/var/www/html
+    depends_on:
+      - db
+
+  db:
+    image: mysql/mysql-server:8.0
+    container_name: wordpress_db
+    restart: always
+    environment:
+      MYSQL_DATABASE: wordpress_db
+      MYSQL_USER: wordpress_user
+      MYSQL_PASSWORD: wordpress_pass
+      MYSQL_ROOT_PASSWORD: root_pass
+    volumes:
+      - db_data:/var/lib/mysql
+
+volumes:
+  wordpress_data:
+  db_data:


### PR DESCRIPTION
## なぜやるか
Docker Compose を使って WordPress とデータベース（MySQL）を連携させたローカル開発環境を構築するため。
ただし、Apple Silicon（M1/M2）環境では互換性のないイメージやポートの競合、コンテナ名の衝突が原因でエラーが発生したため、それらを解消する必要があった。

 ## なにをやったのか
docker-compose.yaml を作成し、WordPress と MySQL コンテナの構成を記述した。

docker compose up -d でコンテナを再起動し、環境を立ち上げた。

 ## 動作確認の手順
ターミナルで以下を実行してコンテナを起動：
docker compose up -d

ブラウザで http://localhost:8000 にアクセス。
